### PR TITLE
Persist WSL_INTEROP in child environment, for WSL2

### DIFF
--- a/wsl-sudo.py
+++ b/wsl-sudo.py
@@ -115,7 +115,9 @@ class ElevatedServer:
             if os.isatty(0):
                 fcntl.ioctl(0, termios.TIOCSWINSZ, winsize)
             envdict[b'ELEVATED_SHELL'] = b'1'
-            envdict[b'WSL_INTEROP'] = os.getenv('WSL_INTEROP')
+            # Undocumented WSL2 env var, required for WSL2 support
+            if b'WSL_INTEROP' in os.environb:
+                envdict[b'WSL_INTEROP'] = os.environb[b'WSL_INTEROP']
             try:
                 os.execvpe(argv[0], argv, envdict)
             except FileNotFoundError:

--- a/wsl-sudo.py
+++ b/wsl-sudo.py
@@ -115,6 +115,7 @@ class ElevatedServer:
             if os.isatty(0):
                 fcntl.ioctl(0, termios.TIOCSWINSZ, winsize)
             envdict[b'ELEVATED_SHELL'] = b'1'
+            envdict[b'WSL_INTEROP'] = os.getenv('WSL_INTEROP')
             try:
                 os.execvpe(argv[0], argv, envdict)
             except FileNotFoundError:


### PR DESCRIPTION
With this patch wsl-sudo.py works for me in WSL2.