### PR TITLE
Add powershell's path

### DIFF
--- a/wsl-sudo.py
+++ b/wsl-sudo.py
@@ -221,7 +221,8 @@ class UnprivilegedClient:
 
                 try:
                     subprocess.check_call(
-                        ["powershell.exe", "Start-Process", "-Verb", "runas",
+                        ["/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+                         "Start-Process", "-Verb", "runas",
                          "-WindowStyle", window_style,
                          "-FilePath", "wsl", "-ArgumentList",
                          '"{}"'.format(subprocess.list2cmdline([

--- a/wsl-sudo.py
+++ b/wsl-sudo.py
@@ -233,7 +233,7 @@ class UnprivilegedClient:
                     print("wudo: failed to start elevated process")
                     return
 
-                listen_socket.settimeout(5)
+                listen_socket.settimeout(10)
                 self.sock, acc = listen_socket.accept()
                 self.channel = MessageChannel(self.sock)
 


### PR DESCRIPTION
Without this change wsl is not finding powershell on boot if this option is false in /etc/wsl.conf:
```
[interop]
appendWindowsPath = false
```