### PR TITLE
Invoke admin wsl with same distribution as caller

### DIFF
--- a/wsl-sudo.py
+++ b/wsl-sudo.py
@@ -219,12 +219,16 @@ class UnprivilegedClient:
 
                 window_style = ['Hidden', 'Minimized', 'Normal'][visibility]
 
+                distro = os.environ['WSL_DISTRO_NAME']
+                distro_args = ['-d', distro] if distro else []
+
                 try:
                     subprocess.check_call(
                         ["powershell.exe", "Start-Process", "-Verb", "runas",
                          "-WindowStyle", window_style,
                          "-FilePath", "wsl", "-ArgumentList",
                          '"{}"'.format(subprocess.list2cmdline([
+                             *distro_args,
                              sys.executable, os.path.abspath(__file__),
                              '--elevated', 'visible' if visibility else 'hidden',
                              str(port), pwf.name]))])


### PR DESCRIPTION
If more than one distribution is installed WSL will use the default one. This commit makes sure it the admin WSL will run in the same WSL distribution as the one which caller wsl-sudo.